### PR TITLE
refactor:  atualiza controllers para recuperar entidades por consulta…

### DIFF
--- a/src/modules/head/head.controller.ts
+++ b/src/modules/head/head.controller.ts
@@ -3,11 +3,18 @@ import {
   Body,
   Controller,
   Get,
-  Param,
+  NotFoundException,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiHeader, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiHeader,
+  ApiTags,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { HeadEntity } from 'src/database/entities/head.mongo-entity';
 import { HeadService } from './head.service';
 import { CreateHeadDTO } from './dto/create-head-dto';
@@ -43,26 +50,8 @@ export class HeadController {
   }
 
   @ApiOperation({
-    summary: 'Resgata informações do head no banco.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Sucesso',
-    type: CreateHeadDTO,
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Erro',
-    type: BadRequestException,
-  })
-  @Get(':email')
-  async getByEmail(@Param('email') email: string): Promise<HeadEntity> {
-    const head = await this.headService.findHeadByEmail(email);
-    return head;
-  }
-
-  @ApiOperation({
-    summary: 'Resgata todos os heads do banco.',
+    summary:
+      'Resgata um head do banco por email ou todos, se nenhum email for fornecido',
   })
   @ApiResponse({
     status: 200,
@@ -71,11 +60,28 @@ export class HeadController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Erro',
+    description: 'Erro ao requisitar o head',
     type: BadRequestException,
   })
+  @ApiResponse({
+    status: 404,
+    description: 'Head não encontrado',
+    type: NotFoundException,
+  })
+  @ApiQuery({
+    name: 'email',
+    description: 'Email do head (opcional)',
+    required: false,
+    type: String,
+  })
   @Get()
-  async getAll(): Promise<HeadEntity[]> {
+  async getAll(
+    @Query('email') email?: string,
+  ): Promise<HeadEntity[] | HeadEntity> {
+    if (email) {
+      const head = await this.headService.findHeadByEmail(email);
+      return head;
+    }
     const heads = await this.headService.findAll();
     return heads;
   }

--- a/src/modules/juniors/juniors.controller.ts
+++ b/src/modules/juniors/juniors.controller.ts
@@ -1,22 +1,29 @@
-import { Body, Controller,  Post, UseGuards, Get, NotFoundException, Query, StreamableFile} from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+  Get,
+  NotFoundException,
+  Query,
+  StreamableFile,
+} from '@nestjs/common';
 import { JuniorsService } from './juniors.service';
 import { CreateJuniorDto } from './dtos/create-junior-dto';
 import { ApiTags } from '@nestjs/swagger';
 import { SecretKeyGuard } from 'src/shared/guards/secret-key.guard';
 import { JuniorMDBEntity } from '../../database/entities/juniormdb.mongo-entity';
-import {AsyncParser} from '@json2csv/node';
+import { AsyncParser } from '@json2csv/node';
 import { FilterJuniorsDTO } from './dtos/filter-junior-dto';
 import { Readable } from 'typeorm/platform/PlatformTools';
 import { GetJuniorsSwagger } from 'src/shared/swagger/decorators/junior/getJuniors.swagger';
 import { CreateJuniorSwagger } from 'src/shared/swagger/decorators/junior/createJunior.swagger';
 import { ExportJuniorsCsvSwagger } from 'src/shared/swagger/decorators/junior/exportJuniorsCsv.swagger';
 
-
 @ApiTags('Junior')
 @Controller('juniors')
 export class JuniorsController {
   constructor(private readonly juniorsService: JuniorsService) {}
-
 
   @Post()
   @UseGuards(SecretKeyGuard)
@@ -30,10 +37,12 @@ export class JuniorsController {
 
   @Get()
   @GetJuniorsSwagger()
-  async getJuniors(@Query('email') email?: string): Promise<JuniorMDBEntity[]> {
-    if(email){
+  async getJuniors(
+    @Query('email') email?: string,
+  ): Promise<JuniorMDBEntity[] | JuniorMDBEntity> {
+    if (email) {
       const junior = await this.juniorsService.findJuniorByEmail(email);
-      return [junior];
+      return junior;
     }
     const juniors = await this.juniorsService.findAll({});
     return juniors;
@@ -41,7 +50,9 @@ export class JuniorsController {
 
   @Get('csv')
   @ExportJuniorsCsvSwagger()
-  async exportJuniorsAsCSV(@Query() filters: FilterJuniorsDTO): Promise<StreamableFile> {
+  async exportJuniorsAsCSV(
+    @Query() filters: FilterJuniorsDTO,
+  ): Promise<StreamableFile> {
     const juniors = await this.juniorsService.findAll(filters);
 
     if (!juniors || juniors.length === 0) {
@@ -58,8 +69,8 @@ export class JuniorsController {
     readableStream.push(null);
 
     return new StreamableFile(readableStream, {
-        disposition: 'attachment; filename="juniors.csv"',
-        type: 'text/csv',
-      });
-    }
+      disposition: 'attachment; filename="juniors.csv"',
+      type: 'text/csv',
+    });
+  }
 }

--- a/src/modules/mentor/mentor.controller.ts
+++ b/src/modules/mentor/mentor.controller.ts
@@ -3,11 +3,18 @@ import {
   Body,
   Controller,
   Get,
-  Param,
+  NotFoundException,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiHeader, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiHeader,
+  ApiTags,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { MentorEntity } from 'src/database/entities/mentor.mongo-entity';
 import { MentorService } from './mentor.service';
 import { CreateMentorDTO } from './dto/create-mentor-dto';
@@ -45,26 +52,8 @@ export class MentorController {
   }
 
   @ApiOperation({
-    summary: 'Resgata informações do mentor no banco.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Sucesso',
-    type: CreateMentorDTO,
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Erro',
-    type: BadRequestException,
-  })
-  @Get(':email')
-  async getByEmail(@Param('email') email: string): Promise<MentorEntity> {
-    const mentor = await this.mentorService.findMentorByEmail(email);
-    return mentor;
-  }
-
-  @ApiOperation({
-    summary: 'Resgata todos os mentores do banco.',
+    summary:
+      'Resgata um mentor do banco por email ou todos, se nenhum email for fornecido',
   })
   @ApiResponse({
     status: 200,
@@ -73,11 +62,28 @@ export class MentorController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Erro',
+    description: 'Erro ao requisitar o mentor',
     type: BadRequestException,
   })
+  @ApiResponse({
+    status: 404,
+    description: 'Mentor não encontrado',
+    type: NotFoundException,
+  })
+  @ApiQuery({
+    name: 'email',
+    description: 'Email do mentor (opcional)',
+    required: false,
+    type: String,
+  })
   @Get()
-  async getAll(): Promise<MentorEntity[]> {
+  async getAll(
+    @Query('email') email?: string,
+  ): Promise<MentorEntity[] | MentorEntity> {
+    if (email) {
+      const mentor = await this.mentorService.findMentorByEmail(email);
+      return mentor;
+    }
     const mentors = await this.mentorService.findAll();
     return mentors;
   }


### PR DESCRIPTION
This pull request refactors multiple controller files to unify the handling of "get by email" and "get all" endpoints for various entities (`head`, `junior`, `mentor`, and `supporter`). The changes streamline the code by combining these endpoints, improving consistency, and enhancing Swagger documentation.

### Unified endpoint refactoring:

* [`src/modules/head/head.controller.ts`](diffhunk://#diff-631ba98ea4d1ceb75e16356243c69aae94bb04171d184ea95f2dc344a13b699eL46-R84): Merged "get by email" and "get all" endpoints into a single endpoint using the `@Query` decorator for optional email filtering. Updated Swagger documentation to reflect the changes and added appropriate response types and descriptions.

* [`src/modules/juniors/juniors.controller.ts`](diffhunk://#diff-c5c3833269b21a6e6315bd8d4932c4ff0be3541f29b0aa5b11cddddfe3bcfd8eL33-R55): Refactored the `getJuniors` method to handle optional email filtering and return either a single junior or a list. Adjusted Swagger decorators for improved documentation.

* [`src/modules/mentor/mentor.controller.ts`](diffhunk://#diff-8c043579de4a8b9946055367105d1d0b93a8f32f49d61395b05d69a649d5b59fL48-R86): Unified "get by email" and "get all" endpoints into one method with optional email filtering. Enhanced Swagger documentation with updated summaries and response descriptions.

* [`src/modules/supporter/supporter.controller.ts`](diffhunk://#diff-5ea45b4a901bfd8d3674c900ef2d28801cc5edff1ea82ca94c73d3045ed3a9f2L48-R87): Combined "get by email" and "get all" endpoints into a single method using optional email filtering. Updated Swagger documentation for clarity and consistency.

### Import statement updates:

* Updated import statements across all affected controller files to include `NotFoundException` and `Query`, reflecting the refactored endpoint logic. [[1]](diffhunk://#diff-631ba98ea4d1ceb75e16356243c69aae94bb04171d184ea95f2dc344a13b699eL6-R17) [[2]](diffhunk://#diff-c5c3833269b21a6e6315bd8d4932c4ff0be3541f29b0aa5b11cddddfe3bcfd8eL1-R10) [[3]](diffhunk://#diff-8c043579de4a8b9946055367105d1d0b93a8f32f49d61395b05d69a649d5b59fL6-R17) [[4]](diffhunk://#diff-5ea45b4a901bfd8d3674c900ef2d28801cc5edff1ea82ca94c73d3045ed3a9f2L6-R17)