### PR TITLE
feat: add phone and hasWhatsApp to head creation

### DIFF
--- a/src/database/entities/head.mongo-entity.ts
+++ b/src/database/entities/head.mongo-entity.ts
@@ -11,6 +11,12 @@ export class HeadEntity{
     @Column({ length: 255})
     email: string;
 
+    @Column({ length: 255 })
+    phone: string;
+
+    @Column()
+    hasWhatsApp: boolean;
+
     @Column({length: 255})
     linkedin: string;
 
@@ -57,7 +63,7 @@ export class HeadEntity{
     contactAgreement: boolean;
 
     @Column()
-    volunteeringAgreement: boolean;
+    volunteerAgreement: boolean;
 
     @Column()
     termsAgreement: boolean;

--- a/src/modules/head/dto/create-head-dto.ts
+++ b/src/modules/head/dto/create-head-dto.ts
@@ -14,6 +14,15 @@ export class CreateHeadDTO{
     @IsNotEmpty()
     email: string;
 
+    @ApiProperty({ description: 'Telefone do mentor', example: '(79) 999999998' })
+    @IsString()
+    @IsNotEmpty()
+    phone: string;
+
+    @ApiProperty({ description: 'Este número possui WhatsApp?', example: true })
+    @IsBoolean()
+    hasWhatsApp: boolean;
+
     @ApiProperty({description: 'LinkedIn do Head', example: 'https://www.linkedin.com/in/jjoestar/'})
     @IsString()
     @IsNotEmpty()


### PR DESCRIPTION
Esse PR resolve a https://github.com/SouJunior/products/issues/1246 adicionando, ao endpoint POST create head, os campos phone e hasWhatsApp.

Prints de validação do endpoint com postman com as requests e mongo com os dados salvos
<img width="1920" height="1080" alt="Captura de Tela (105)" src="https://github.com/user-attachments/assets/04570a49-36cd-40b6-85a7-1248794faf29" />
<img width="1920" height="1080" alt="Captura de Tela (104)" src="https://github.com/user-attachments/assets/cadfeca7-7685-487a-b35d-4c00a14e12ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Release

* **Novos Recursos**
  * Adicionados campos para capturar número de telefone dos mentores e indicar disponibilidade no WhatsApp, facilitando uma comunicação mais eficiente
  
* **Correções**
  * Nomenclatura de um campo existente foi corrigida para maior consistência e clareza

<!-- end of auto-generated comment: release notes by coderabbit.ai -->